### PR TITLE
Always log performance, even for clean runs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,13 @@
 import assert = require("assert");
 import { ChildProcess, exec, fork } from "child_process";
 import { pathExists, readdir, remove } from "fs-extra";
-import { cpus } from "os";
+import { cpus, homedir } from "os";
 import { join as joinPaths } from "path";
 import { readdirSync, readFileSync } from 'fs';
 import { percentile } from 'stats-lite';
 
 const pathToDtsLint = require.resolve("dtslint");
+const perfDir = joinPaths(homedir(), ".dts", "perf");
 
 if (module.parent === null) { // tslint:disable-line no-null-keyword
     let clone = false;
@@ -162,8 +163,8 @@ function logPerformance() {
     console.log("\n\n=== PERFORMANCE ===\n");
     let big: Array<[string, number]> = [];
     let types: number[] = [];
-    for (const filename of readdirSync('/home/nathansa/.dts/perf/', { encoding: "utf8" })) {
-        const x = JSON.parse(readFileSync('/home/nathansa/.dts/perf/' + filename, { encoding: 'utf8' })) as { [s: string]: { typeCount: number, memory: number } };
+    for (const filename of readdirSync(perfDir, { encoding: "utf8" })) {
+        const x = JSON.parse(readFileSync(perfDir + filename, { encoding: 'utf8' })) as { [s: string]: { typeCount: number, memory: number } };
         for (const k of Object.keys(x)) {
             big.push([k, x[k].typeCount]);
             types.push(x[k].typeCount);

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,11 +140,11 @@ async function main(clone: string | boolean, nProcesses: number, noInstall: bool
         },
     });
 
+    logPerformance();
+
     if (allFailures.length === 0) {
         return 0;
     }
-
-    logPerformance();
 
     console.error("\n\n=== ERRORS ===\n");
 


### PR DESCRIPTION
It usually fails, so I didn't notice. Oops.