### PR TITLE
protractor-browser-logs is fixed

### DIFF
--- a/expectedFailures.txt
+++ b/expectedFailures.txt
@@ -1,4 +1,3 @@
-protractor-browser-logs
 electron-localshortcut
 electron-prompt
 electron-window-state


### PR DESCRIPTION
Since angular/protractor#5326 and https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42319/files#diff-67bcceff526725301f3114a45de5ad01